### PR TITLE
Stop bar manager to avoid broken shells

### DIFF
--- a/nsz/__init__.py
+++ b/nsz/__init__.py
@@ -199,7 +199,7 @@ def main():
 			
 			for i in range(parallelTasks):
 				bars[i].close(clear=True)
-			#barManager.stop() #We aren’t using stop because of it printing garbage to the console.
+			barManager.stop()
 
 			for filePath in sourceFileToDelete:
 				delete_source_file(filePath)


### PR DESCRIPTION
Using the current version of nsz, I always have a broken shell after I compressed a file successfully. At least, I do have a missing cursor in the shell (it is invisible) and I need to `reset` the shell for everything to work properly again. Stopping the progress bar manager after usage helps to mitigate this issue.

In contrast to the comment in code that says that stopping the bar manager outputs garbage, it fixes the invisible cursor problem and generates **no** additional output.