### PR TITLE
Get masterKeyRevision from the right place.

### DIFF
--- a/nsz/Fs/Ticket.py
+++ b/nsz/Fs/Ticket.py
@@ -47,15 +47,13 @@ class Ticket(File):
 		self.titleKeyBlock = self.read(0x100)
 		self.readInt8() # unknown
 		self.keyType = self.readInt8()
-		self.read(0x4) # unknown
+		self.read(0x3) # unknown
 		self.masterKeyRevision = self.readInt8()
-		self.read(0x9) # unknown
+		self.read(0xA) # unknown
 		self.ticketId = hx(self.read(0x8)).decode('utf-8')
 		self.deviceId = hx(self.read(0x8)).decode('utf-8')
 		self.rightsId = hx(self.read(0x10)).decode('utf-8')
 		self.accountId = hx(self.read(0x4)).decode('utf-8')
-		self.seek(0x286)
-		self.masterKeyRevision = self.readInt8()
 
 	def seekStart(self, offset):
 		self.seek(0x4 + self.signatureSizes[self.signatureType] + self.signaturePadding + offset)


### PR DESCRIPTION
Fixes an exception with "nsz -i".

Worth noting: even the getMasterKeyRevision() function here gets it from this location, so this is kind of obviously an error. 

Some tickets have a 0x20 or 0x28 in the next byte, so it would send this value up for decryption and get confused.  More often it's 0, and that seems to "work".