### PR TITLE
We don't want to touch the default Kivy font but instead use LabelBase to set DEFAULT_FONT for this specific application

### DIFF
--- a/nsz/gui/NSZ_GUI.py
+++ b/nsz/gui/NSZ_GUI.py
@@ -1,6 +1,6 @@
 from nsz.gui.GuiPath import *
 from kivy.config import Config
-Config.set("kivy", "default_font", ["MPLUS1p", getGuiPath("fonts/MPLUS1p-Medium.ttf")])
+from kivy.core.text import LabelBase, DEFAULT_FONT
 from kivy.app import App
 from kivy.core.window import Window
 from kivy.uix.widget import Widget
@@ -16,12 +16,12 @@ from nsz.gui.SettingScrollOptions import *
 import logging
 import os
 
-
 class GUI(App):
 	
 	rootWidget = None
 	
 	def run(self):
+		LabelBase.register(DEFAULT_FONT, getGuiPath('fonts/MPLUS1p-Medium.ttf'))
 		super(GUI, self).run()
 		Window.close()
 		if not self.rootWidget.hardExit:


### PR DESCRIPTION
This fixes #154