### PR TITLE
Allow NSP header to align to 16 bytes

### DIFF
--- a/nsz/Fs/Nsp.py
+++ b/nsz/Fs/Nsp.py
@@ -369,13 +369,13 @@ class Nsp(Pfs0):
 				nca.header.setIsGameCard(targetValue)
 
 
-	def pack(self, files):
+	def pack(self, files, fix_padding):
 		if not self.path:
 			return False
 
 		Print.info('\tRepacking to NSP...')
 
-		hd = self.generateHeader(files)
+		hd = self.generateHeader(files, fix_padding)
 
 		totalSize = len(hd) + sum(os.path.getsize(file) for file in files)
 		if os.path.exists(self.path) and os.path.getsize(self.path) == totalSize:
@@ -405,10 +405,14 @@ class Nsp(Pfs0):
 		Print.info('\t\tRepacked to %s!' % outf.name)
 		outf.close()
 
-	def generateHeader(self, files):
+	def generateHeader(self, files, fix_padding):
 		filesNb = len(files)
 		stringTable = '\x00'.join(os.path.basename(file) for file in files)
 		headerSize = 0x10 + (filesNb)*0x18 + len(stringTable)
+		if fix_padding:
+			paddingSize = (16 - headerSize % 16) % 16
+			stringTable += '\x00' * paddingSize
+			headerSize = 0x10 + (filesNb)*0x18 + len(stringTable)
 
 		fileSizes = [os.path.getsize(file) for file in files]
 		fileOffsets = [sum(fileSizes[:n]) for n in range(filesNb)]

--- a/nsz/__init__.py
+++ b/nsz/__init__.py
@@ -189,7 +189,7 @@ def main():
 			Print.info('Creating "{0}"'.format(args.create))
 			nsp = Nsp.Nsp(None, None)
 			nsp.path = args.create
-			nsp.pack(args.file)
+			nsp.pack(args.file, args.fix_padding)
 
 		if args.C:
 			if args.verify and not args.quick_verify and not args.keep:


### PR DESCRIPTION
From my observation, many NSP from scene releases or no-intro have their headers aligned to 16 bytes. So I make `-F` parameters also affect alignment of header.

Tested on my computer, and now running `nsz -F --create <out.nsp> <files_unpacked_from_scene...>` can generate identical NSP file.