### PR TITLE
Fix Xcz decompressing partition overwritting

### DIFF
--- a/nsz/Fs/Hfs0.py
+++ b/nsz/Fs/Hfs0.py
@@ -46,7 +46,7 @@ class Hfs0Stream(BaseFile):
 
 	def add(self, name, size, pleaseNoPrint = None):
 		if self.written:
-			self.addpos = self.tell()
+			self.addpos = self.actualSize
 			self.written = False
 		Print.info(f'[ADDING]     {name} {hex(size)} bytes to HFS0 at {hex(self.addpos)}', pleaseNoPrint)
 		partition = self.partition(self.addpos, size, n = BaseFile())


### PR DESCRIPTION
Decompressing Xcz into Xci actually results in update/normal/logo partitions being scrambled. This is because in method __decompressXcz from NszDecompressor.py, when partitionOut gets destroyed, Hfs0Stream.close is called, and this method calls seek(0)... So the position given by tell is not at the end of file anymore, subsequent partitions overwrite previous ones, and only the last partition (secure) is correct.