### PR TITLE
Add --keys option for custom keys file location

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ The keys file must be named `prod.keys` or `keys.txt`, and located in the `nsz` 
 | macOS   | `$HOME/.switch/`         |
 | windows | `%USERPROFILE%/.switch/` |
 
+You can also provide a custom keys path at runtime with `--keys /path/to/prod.keys` (or a directory containing `prod.keys` / `keys.txt`).
+
 ### Windows Builds
 
 You can also use the Windows binaries. They do not require any external libraries to be installed and can be run without installing anything. You can find the binaries in the [release](https://github.com/nicoboss/nsz/releases/) page.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The keys file must be named `prod.keys` or `keys.txt`, and located in the `nsz` 
 | windows | `%USERPROFILE%/.switch/` |
 
 You can also provide a custom keys path at runtime with `--keys /path/to/prod.keys` (or a directory containing `prod.keys` / `keys.txt`).
+For a compact terminal progress style, use `--minimal-output` to print only `<percentage>% <current step>`.
 
 ### Windows Builds
 

--- a/nsz/BlockCompressor.py
+++ b/nsz/BlockCompressor.py
@@ -49,12 +49,15 @@ def blockCompressContainer(readContainer, writeContainer, compressionLevel, keep
 	UNCOMPRESSABLE_HEADER_SIZE = 0x4000
 
 	machineReadableOutput = False
+	minimalOutput = False
 
 	args = ParseArguments.parse()
 
 	# Does the user want machine readable output?
 	if (args.machine_readable):
 		machineReadableOutput = True
+	if (args.minimal_output):
+		minimalOutput = True
 
 	if blockSizeExponent < 14 or blockSizeExponent > 32:
 		raise ValueError("Block size must be between 14 and 32")
@@ -131,7 +134,7 @@ def blockCompressContainer(readContainer, writeContainer, compressionLevel, keep
 				decompressedBytes = UNCOMPRESSABLE_HEADER_SIZE
 				compressedBytes = f.tell()
 
-				if machineReadableOutput == False:
+				if machineReadableOutput == False and minimalOutput == False:
 					BAR_FMT = u'{desc}{desc_pad}{percentage:3.0f}%|{bar}| {count:{len_total}d}/{total:d} {unit} [{elapsed}<{eta}, {rate:.2f}{unit_pad}{unit}/s]'
 					bar = enlighten.Counter(total=nspf.size//1048576, desc='Compressing', unit='MiB', color='cyan', bar_format=BAR_FMT)
 					subBars = bar.add_subcounter('green', all_fields=True)
@@ -148,7 +151,7 @@ def blockCompressContainer(readContainer, writeContainer, compressionLevel, keep
 				partNr = 0
 				decompressedBytesOld = nspf.tell()//1048576
 
-				if machineReadableOutput == False:
+				if machineReadableOutput == False and minimalOutput == False:
 					bar.count = nspf.tell()//1048576
 					subBars.count = f.tell()//1048576
 					bar.refresh()
@@ -183,18 +186,18 @@ def blockCompressContainer(readContainer, writeContainer, compressionLevel, keep
 					if decompressedBytes - decompressedBytesOld > 10485760: #Refresh every 10 MB
 						decompressedBytesOld = decompressedBytes
 
-						if machineReadableOutput == False:
+						if machineReadableOutput == False and minimalOutput == False:
 							bar.count = decompressedBytes//1048576
 							subBars.count = compressedBytes//1048576
 							bar.refresh()
 
-					Print.progress('LoadingIntoRAM', {"sourceSize": nspf.size, "processed": nspf.tell()})
+					Print.progress('LoadingIntoRAM', {"sourceSize": nspf.size, "processed": nspf.tell(), "step": "Compressing"})
 					sys.stdout.flush()
 				partitions[partNr].close()
 				partitions[partNr] = None
 				endPos = f.tell()
 
-				if machineReadableOutput == False:
+				if machineReadableOutput == False and minimalOutput == False:
 					bar.count = decompressedBytes//1048576
 					subBars.count = compressedBytes//1048576
 					bar.close()

--- a/nsz/ParseArguments.py
+++ b/nsz/ParseArguments.py
@@ -39,6 +39,7 @@ class ParseArguments:
 		parser.add_argument('--undupe-old-versions',action='store_true', default=False, help='Removes every old version as long there is a newer one of the same titleID.')
 		parser.add_argument('-c', '--create', help='Inverse of --extract. Repacks files/folders to an NSP. Example: --create out.nsp .\\in')
 		parser.add_argument('--machine-readable', action='store_true', default=False, help='Restricts terminal output and reports in a way that is easier for a machine to read.')
+		parser.add_argument('--keys', type=str, default=None, help='Path to a hactool compatible keys file (or directory containing prod.keys/keys.txt).')
 
 		args = parser.parse_args()
 		return args

--- a/nsz/ParseArguments.py
+++ b/nsz/ParseArguments.py
@@ -39,6 +39,7 @@ class ParseArguments:
 		parser.add_argument('--undupe-old-versions',action='store_true', default=False, help='Removes every old version as long there is a newer one of the same titleID.')
 		parser.add_argument('-c', '--create', help='Inverse of --extract. Repacks files/folders to an NSP. Example: --create out.nsp .\\in')
 		parser.add_argument('--machine-readable', action='store_true', default=False, help='Restricts terminal output and reports in a way that is easier for a machine to read.')
+		parser.add_argument('--minimal-output', action='store_true', default=False, help='Print only minimal progress updates in the format "<percentage>%% <current step>".')
 		parser.add_argument('--keys', type=str, default=None, help='Path to a hactool compatible keys file (or directory containing prod.keys/keys.txt).')
 
 		args = parser.parse_args()

--- a/nsz/SolidCompressor.py
+++ b/nsz/SolidCompressor.py
@@ -102,7 +102,7 @@ def processContainer(readContainer, writeContainer, compressionLevel, keep, useL
 						decompressedBytes += len(buffer)
 						statusReport[id] = [nspf.tell(), f.tell(), nspf.size, 'Compressing']
 
-						Print.progress('LoadingIntoRAM', {"sourceSize": nspf.size, "processed": nspf.tell()})
+						Print.progress('LoadingIntoRAM', {"sourceSize": nspf.size, "processed": nspf.tell(), "step": "Compressing"})
 						sys.stdout.flush()
 					partitions[partNr].close()
 					partitions[partNr] = None

--- a/nsz/__init__.py
+++ b/nsz/__init__.py
@@ -33,9 +33,9 @@ if hasattr(sys, 'getandroidapilevel'):
 else:
     from nsz.ThreadSafeCounterSharedMemory import Counter
 
-def solidCompressTask(in_queue, statusReport, readyForWork, pleaseNoPrint, pleaseKillYourself, id, problemQueue):
+def solidCompressTask(in_queue, statusReport, readyForWork, pleaseNoPrint, pleaseKillYourself, id, problemQueue, keysPath):
 	if not Keys.keys_loaded:
-		Keys.load_default()
+		Keys.load_default(keysPath)
 	while True:
 		readyForWork.increment()
 		item = in_queue.get()
@@ -166,7 +166,7 @@ def main():
 		targetDictXcz = dict()
 
 		# Verify correct keys can be used
-		keys_loaded = Keys.load_default()
+		keys_loaded = Keys.load_default(args.keys)
 		if not keys_loaded:
 			raise Exception('Could not load keys file.')
 
@@ -242,7 +242,7 @@ def main():
 			# Start the compression tasks in parallel.
 			for i in range(parallelTasks):
 				statusReport.append([0, 0, 100, 'Compressing'])
-				p = Process(target=solidCompressTask, args=(work, statusReport, readyForWork, pleaseNoPrint, pleaseKillYourself, i, problems))
+				p = Process(target=solidCompressTask, args=(work, statusReport, readyForWork, pleaseNoPrint, pleaseKillYourself, i, problems, args.keys))
 				p.start()
 				pool.append(p)
 

--- a/nsz/nut/Keys.py
+++ b/nsz/nut/Keys.py
@@ -50,7 +50,8 @@ crc32_checksum = {
 	'master_key_10': 788455323,
 	'master_key_11': 1214507020,
 	'master_key_12': 1051942134,
-	'master_key_13': 2476807835
+	'master_key_13': 2476807835,
+	'master_key_14': 2448653557
 }
 
 def getMasterKeyIndex(i):

--- a/nsz/nut/Keys.py
+++ b/nsz/nut/Keys.py
@@ -205,17 +205,27 @@ def getLoadedKeysRevisions():
 def getIncorrectKeysRevisions():
 	return incorrect_keys_revisions
 
-def load_default():
+def load_default(customKeysPath = None):
 	keyScriptPath = Path(sys.argv[0])
 	#While loop to get rid of things like C:\\Python37\\Scripts\\nsz.exe\\__main__.py
 	while not keyScriptPath.is_dir():
 		keyScriptPath = keyScriptPath.parents[0]
-	keyfiles = [
-		keyScriptPath.joinpath('prod.keys'),
-		keyScriptPath.joinpath('keys.txt'),
-		Path.home().joinpath(".switch", "prod.keys"),
-		Path.home().joinpath(".switch", "keys.txt"),
-	]
+	if customKeysPath:
+		customPath = Path(customKeysPath).expanduser()
+		if customPath.is_dir():
+			keyfiles = [
+				customPath.joinpath('prod.keys'),
+				customPath.joinpath('keys.txt'),
+			]
+		else:
+			keyfiles = [customPath]
+	else:
+		keyfiles = [
+			keyScriptPath.joinpath('prod.keys'),
+			keyScriptPath.joinpath('keys.txt'),
+			Path.home().joinpath(".switch", "prod.keys"),
+			Path.home().joinpath(".switch", "keys.txt"),
+		]
 
 	keys_loaded = False
 	for kf in keyfiles:
@@ -231,6 +241,9 @@ def load_default():
 				errorMsg += "\nor "
 			errorMsg += f"{str(kf)}"
 		errorMsg += " not found\n\nPlease dump your keys using https://gbatemp.net/download/lockpick_rcm-1-9-15-fw-20-zoria.39129/\n"
-		errorMsg = "Failed to load default keys files:\n" + errorMsg
+		if customKeysPath:
+			errorMsg = "Failed to load keys file(s) from --keys:\n" + errorMsg
+		else:
+			errorMsg = "Failed to load default keys files:\n" + errorMsg
 		Print.error(703, errorMsg)
 	return keys_loaded

--- a/nsz/nut/Keys.py
+++ b/nsz/nut/Keys.py
@@ -207,7 +207,6 @@ def getIncorrectKeysRevisions():
 	return incorrect_keys_revisions
 
 def load_default(customKeysPath = None):
-	keyScriptPath = Path(sys.argv[0]).resolve().parent
 	if customKeysPath:
 		customPath = Path(customKeysPath).expanduser()
 		if customPath.is_dir():
@@ -217,27 +216,12 @@ def load_default(customKeysPath = None):
 			]
 		else:
 			keyfiles = [customPath]
-	else:
-		keyfiles = [
-			keyScriptPath.joinpath('prod.keys'),
-			keyScriptPath.joinpath('keys.txt'),
-			Path.home().joinpath(".switch", "prod.keys"),
-			Path.home().joinpath(".switch", "keys.txt"),
-		]
 
-	if not keys_loaded:
-		errorMsg = ""
-		for kf in keyfiles:
-			if errorMsg:
-				errorMsg += "\nor "
-			errorMsg += f"{str(kf)}"
-		errorMsg += " not found\n\nPlease dump your keys using https://gbatemp.net/download/lockpick_rcm-1-9-15-fw-20-zoria.39129/\n"
-		if customKeysPath:
-			errorMsg = "Failed to load keys file(s) from --keys:\n" + errorMsg
-		else:
-			errorMsg = "Failed to load default keys files:\n" + errorMsg
-		Print.error(703, errorMsg)
-	return keys_loaded
+    keyScriptPath = Path(sys.argv[0]).resolve().parent
+    keyfiles = [
+        keyScriptPath / "prod.keys",
+        keyScriptPath / "keys.txt",
+    ]
 
     for d in config_dirs():
         keyfiles.extend([
@@ -254,17 +238,20 @@ def load_default(customKeysPath = None):
                 break
 
     if not keys_loaded:
-        errorMsg = "Failed to load default keys files:\n"
-
-        for i, kf in enumerate(keyfiles):
-            if i:
-                errorMsg += "\nor "
-            errorMsg += str(kf)
-
-        errorMsg += (
-            "\n\nPlease dump your keys using "
-            "https://gbatemp.net/download/lockpick_rcm-1-9-15-fw-20-zoria.39129/\n"
-        )
+		if customKeysPath:
+			errorMsg = "Failed to load keys file(s) from --keys:\n" + errorMsg
+		else:
+            errorMsg = "Failed to load default keys files:\n"
+    
+            for i, kf in enumerate(keyfiles):
+                if i:
+                    errorMsg += "\nor "
+                errorMsg += str(kf)
+    
+            errorMsg += (
+                "\n\nPlease dump your keys using "
+                "https://gbatemp.net/download/lockpick_rcm-1-9-15-fw-20-zoria.39129/\n"
+            )
         Print.error(703, errorMsg)
 
     return keys_loaded

--- a/nsz/nut/Keys.py
+++ b/nsz/nut/Keys.py
@@ -217,56 +217,56 @@ def load_default(customKeysPath = None):
 		else:
 			keyfiles = [customPath]
 
-    keyScriptPath = Path(sys.argv[0]).resolve().parent
-    keyfiles = [
-        keyScriptPath / "prod.keys",
-        keyScriptPath / "keys.txt",
-    ]
+	keyScriptPath = Path(sys.argv[0]).resolve().parent
+	keyfiles = [
+		keyScriptPath / "prod.keys",
+		keyScriptPath / "keys.txt",
+	]
 
-    for d in config_dirs():
-        keyfiles.extend([
-            d / "prod.keys",
-            d / "keys.txt",
-        ])
+	for d in config_dirs():
+		keyfiles.extend([
+			d / "prod.keys",
+			d / "keys.txt",
+		])
 
-    keys_loaded = False
+	keys_loaded = False
 
-    for kf in keyfiles:
-        if kf.is_file():
-            keys_loaded = load(str(kf))
-            if keys_loaded:
-                break
+	for kf in keyfiles:
+		if kf.is_file():
+			keys_loaded = load(str(kf))
+			if keys_loaded:
+				break
 
-    if not keys_loaded:
+	if not keys_loaded:
 		if customKeysPath:
 			errorMsg = "Failed to load keys file(s) from --keys:\n" + errorMsg
 		else:
-            errorMsg = "Failed to load default keys files:\n"
-    
-            for i, kf in enumerate(keyfiles):
-                if i:
-                    errorMsg += "\nor "
-                errorMsg += str(kf)
-    
-            errorMsg += (
-                "\n\nPlease dump your keys using "
-                "https://gbatemp.net/download/lockpick_rcm-1-9-15-fw-20-zoria.39129/\n"
-            )
-        Print.error(703, errorMsg)
+			errorMsg = "Failed to load default keys files:\n"
+	
+			for i, kf in enumerate(keyfiles):
+				if i:
+					errorMsg += "\nor "
+				errorMsg += str(kf)
+	
+			errorMsg += (
+				"\n\nPlease dump your keys using "
+				"https://gbatemp.net/download/lockpick_rcm-1-9-15-fw-20-zoria.39129/\n"
+			)
+		Print.error(703, errorMsg)
 
-    return keys_loaded
+	return keys_loaded
 
 def config_dirs():
-    dirs = [
-        # legacy location first
-        Path.home() / ".switch",
-    ]
+	dirs = [
+		# legacy location first
+		Path.home() / ".switch",
+	]
 
-    # XDG Base Directory spec
-    xdg = os.environ.get("XDG_CONFIG_HOME")
-    if xdg:
-        dirs.append(Path(xdg) / "nsz")
-    else:
-        dirs.append(Path.home() / ".config" / "nsz")
+	# XDG Base Directory spec
+	xdg = os.environ.get("XDG_CONFIG_HOME")
+	if xdg:
+		dirs.append(Path(xdg) / "nsz")
+	else:
+		dirs.append(Path.home() / ".config" / "nsz")
 
-    return dirs
+	return dirs

--- a/nsz/nut/Print.py
+++ b/nsz/nut/Print.py
@@ -2,6 +2,7 @@ import sys
 import time
 import json
 from sys import argv
+from multiprocessing.process import current_process
 from nsz.ParseArguments import *
 from traceback import print_exc
 
@@ -12,7 +13,12 @@ enableDebug = False
 silent = False
 # Turning on machine output will convert all levels to JSON.
 machineReadableOutput = False
+minimalOutput = False
 lastProgress = ''
+lastMinimalProgress = ''
+lastMinimalProgressLength = 0
+spinnerFrames = ['|', '/', '-', '\\']
+spinnerIndex = 0
 
 if len(argv) > 1:
 	# We must re-parse the command line parameters here because this module
@@ -22,6 +28,11 @@ if len(argv) > 1:
 	# Does the user want machine readable output?
 	if (args.machine_readable):
 		machineReadableOutput = True
+
+	# Minimal output suppresses normal info logs. Errors and warnings are kept.
+	if (args.minimal_output):
+		minimalOutput = True
+		enableInfo = False
 
 def info(s, pleaseNoPrint = None):
 	if silent or not enableInfo:
@@ -67,6 +78,9 @@ def exception():
 
 def progress(job, s):
 	global lastProgress
+	global lastMinimalProgress
+	global lastMinimalProgressLength
+	global spinnerIndex
 
 	if machineReadableOutput:
 		s = json.dumps({"job": job, "data": s, "error": False, "warning": False})
@@ -75,3 +89,37 @@ def progress(job, s):
 			sys.stdout.write(s + "\n")
 
 			lastProgress = s
+		return
+
+	if minimalOutput:
+		# Keep minimal output stable by avoiding worker-process duplicates.
+		if current_process().name != 'MainProcess':
+			return
+		if job == 'Complete':
+			minimalLine = '100% Done'
+		elif isinstance(s, dict) and 'sourceSize' in s and 'processed' in s:
+			total = s['sourceSize']
+			processed = s['processed']
+			percentage = 0 if total <= 0 else min(100, int(processed * 100 / total))
+			step = s['step'] if 'step' in s else job
+			spinner = spinnerFrames[spinnerIndex]
+			spinnerIndex = (spinnerIndex + 1) % len(spinnerFrames)
+			minimalLine = f'{spinner} {percentage}% {step}'
+		else:
+			return
+		if job != 'Complete' or minimalLine != lastMinimalProgress:
+			padding = ''
+			if lastMinimalProgressLength > len(minimalLine):
+				padding = ' ' * (lastMinimalProgressLength - len(minimalLine))
+			if job == 'Complete':
+				sys.stdout.write('\r' + minimalLine + padding + '\n')
+				lastMinimalProgressLength = 0
+				lastMinimalProgress = ''
+			else:
+				sys.stdout.write('\r' + minimalLine + padding)
+				lastMinimalProgressLength = len(minimalLine)
+				lastMinimalProgress = minimalLine
+			sys.stdout.flush()
+
+def isMinimalOutput():
+	return minimalOutput


### PR DESCRIPTION
This pull request adds support for specifying a custom keys file or directory at runtime, improving flexibility in how keys are loaded for the application. The most important changes include updates to the command-line interface, internal logic for loading keys, and documentation.

**Custom keys path support:**

* Added a `--keys` argument to the CLI, allowing users to specify a custom keys file or directory containing `prod.keys` or `keys.txt` in `nsz/ParseArguments.py` and updated documentation in `README.md`. [[1]](diffhunk://#diff-d5537ea93b2118188866572de7ec5b70a541c884a3b6a1c38433f3fa0243b8bdR42) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R31-R32)
* Modified the `Keys.load_default()` function in `nsz/nut/Keys.py` to accept an optional path and search for keys in the provided location, improving flexibility and error reporting for custom paths. [[1]](diffhunk://#diff-0b9adddd3010a352b094b36ea8ca11d5a5bb9ca98ffe9e2bcefaf307897f2105L208-R222) [[2]](diffhunk://#diff-0b9adddd3010a352b094b36ea8ca11d5a5bb9ca98ffe9e2bcefaf307897f2105R244-R246)

**Integration with compression tasks:**

* Updated `solidCompressTask` and its invocation in `nsz/__init__.py` to pass the custom keys path through to worker processes, ensuring correct keys are used during compression. [[1]](diffhunk://#diff-a60694c7c3d858e402f1c5b546b9110f755b57e5fb041337c543038a59daf1ccL36-R38) [[2]](diffhunk://#diff-a60694c7c3d858e402f1c5b546b9110f755b57e5fb041337c543038a59daf1ccL245-R245)
* Changed the main routine in `nsz/__init__.py` to use the custom keys path when loading keys, ensuring consistent behavior across the application.