### PR TITLE
Add for_nutPrint argument to parse method for flexible help

### DIFF
--- a/nsz/ParseArguments.py
+++ b/nsz/ParseArguments.py
@@ -2,8 +2,8 @@ from argparse import ArgumentParser
 
 class ParseArguments:
 	@staticmethod
-	def parse():
-		parser = ArgumentParser()
+	def parse(for_nutPrint = False):
+		parser = ArgumentParser(add_help = not for_nutPrint)
 		parser.add_argument('file', nargs='*')
 		parser.add_argument('-C', action='store_true', help='Compress NSP/XCI')
 		parser.add_argument('-D', action='store_true', help='Decompress NSZ/XCZ/NCZ')
@@ -42,5 +42,8 @@ class ParseArguments:
 		parser.add_argument('--minimal-output', action='store_true', default=False, help='Print only minimal progress updates in the format "<percentage>%% <current step>".')
 		parser.add_argument('--keys', type=str, default=None, help='Path to a hactool compatible keys file (or directory containing prod.keys/keys.txt).')
 
-		args = parser.parse_args()
+		if for_nutPrint:
+			args, _unknown = parser.parse_known_args()
+		else:
+			args = parser.parse_args()
 		return args

--- a/nsz/nut/Print.py
+++ b/nsz/nut/Print.py
@@ -23,7 +23,7 @@ spinnerIndex = 0
 if len(argv) > 1:
 	# We must re-parse the command line parameters here because this module
 	# is re-imported in multiple modules which resets the variables each import.
-	args = ParseArguments.parse()
+	args = ParseArguments.parse(for_nutPrint = True)
 
 	# Does the user want machine readable output?
 	if (args.machine_readable):


### PR DESCRIPTION
## Summary

This PR updates argument parsing for `nut.Print` so it can safely re-parse command-line options without failing on arguments it does not need.

## Changes

- Adds an optional `for_nutPrint` mode to `ParseArguments.parse()`.
- Disables argparse help handling when parsing from `nut.Print`.
- Uses `parse_known_args()` for `nut.Print` so unknown arguments are ignored instead of causing an error.
- Updates `nut.Print` to call `ParseArguments.parse(for_nutPrint = True)` when checking `--machine-readable` and `--minimal-output`.

## Why

`nut.Print` is imported by multiple modules and re-parses command-line arguments during import to configure output behavior. Before this change, it used the full parser and could fail when unrelated or context-specific arguments were present.

This makes output-option parsing more tolerant while keeping normal CLI parsing unchanged.