### PR TITLE
Improvements to use nsz as a library

### DIFF
--- a/nsz/BlockCompressor.py
+++ b/nsz/BlockCompressor.py
@@ -49,6 +49,8 @@ def blockCompress(
     blockSizeExponent,
     outputDir,
     threads,
+    statusReport=None,
+    id=0,
 ):
     if filePath.suffix == ".nsp":
         return blockCompressNsp(
@@ -60,6 +62,8 @@ def blockCompress(
             blockSizeExponent,
             outputDir,
             threads,
+            statusReport,
+            id,
         )
     elif filePath.suffix == ".xci":
         return blockCompressXci(
@@ -71,6 +75,8 @@ def blockCompress(
             blockSizeExponent,
             outputDir,
             threads,
+            statusReport,
+            id,
         )
 
 
@@ -82,12 +88,16 @@ def blockCompressContainer(
     useLongDistanceMode,
     blockSizeExponent,
     threads,
+    statusReport=None,
+    id=0,
 ):
     CHUNK_SZ = 0x100000
     INCOMPRESSIBLE_HEADER_SIZE = 0x4000
 
     machineReadableOutput = Print.machineReadableOutput
     minimalOutput = Print.isMinimalOutput()
+    # When the caller polls a statusReport dict, skip the enlighten bars entirely
+    useBars = statusReport is None and not machineReadableOutput and not minimalOutput
 
     if blockSizeExponent < 14 or blockSizeExponent > 32:
         raise ValueError("Block size must be between 14 and 32")
@@ -117,7 +127,7 @@ def blockCompressContainer(
     WRITTEN_FMT = "{desc}{desc_pad}{count:.2j}B [{elapsed}, {rate:.2j}B/s]"
     WRITTEN_DESC = "Compressing Written"
     READ_DESC = "Compressing Read".ljust(len(WRITTEN_DESC))
-    if not machineReadableOutput and not minimalOutput:
+    if useBars:
         barManager = enlighten.get_manager()
 
     for nspf in readContainer:
@@ -228,9 +238,11 @@ def blockCompressContainer(
                 f.write(header)
                 decompressedBytes = INCOMPRESSIBLE_HEADER_SIZE
                 compressedBytes = f.tell()
+                if statusReport is not None:
+                    statusReport[id] = [decompressedBytes, compressedBytes, nspf.size, "Compressing"]
                 reportProgress(compressedBytes, nspf.size)
 
-                if not machineReadableOutput and not minimalOutput:
+                if useBars:
                     assert barManager is not None
                     if bar is None:
                         bar = barManager.counter(
@@ -283,7 +295,7 @@ def blockCompressContainer(
                 partNr = 0
                 decompressedBytesOld = nspf.tell() // 1048576
 
-                if not machineReadableOutput and not minimalOutput:
+                if useBars:
                     assert bar is not None and writtenBar is not None
                     bar.count = nspf.tell() // 1048576
                     writtenBar.count = float(f.tell())
@@ -331,7 +343,9 @@ def blockCompressContainer(
                     ):  # Refresh every 10 MB
                         decompressedBytesOld = decompressedBytes
 
-                        if not machineReadableOutput and not minimalOutput:
+                        if statusReport is not None:
+                            statusReport[id] = [decompressedBytes, compressedBytes, nspf.size, "Compressing"]
+                        if useBars:
                             assert bar is not None and writtenBar is not None
                             bar.count = decompressedBytes // 1048576
                             writtenBar.count = float(compressedBytes)
@@ -346,7 +360,9 @@ def blockCompressContainer(
                 endPos = f.tell()
                 written = endPos - startPos
 
-                if not machineReadableOutput and not minimalOutput:
+                if statusReport is not None:
+                    statusReport[id] = [decompressedBytes, written, nspf.size, "Compressing"]
+                if useBars:
                     assert bar is not None and writtenBar is not None
                     bar.count = bar.total
                     writtenBar.count = float(written)
@@ -407,6 +423,8 @@ def blockCompressNsp(
     blockSizeExponent,
     outputDir,
     threads,
+    statusReport=None,
+    id=0,
 ):
     filePath = filePath.resolve()
     container = Nsp.Nsp()
@@ -433,6 +451,8 @@ def blockCompressNsp(
                 useLongDistanceMode,
                 blockSizeExponent,
                 threads,
+                statusReport,
+                id,
             )
 
         Print.progress("Complete", {"filePath": str(nszPath)})
@@ -462,6 +482,8 @@ def blockCompressXci(
     blockSizeExponent,
     outputDir,
     threads,
+    statusReport=None,
+    id=0,
 ):
     filePath = filePath.resolve()
     container = Xci.Xci()
@@ -490,6 +512,8 @@ def blockCompressXci(
                             useLongDistanceMode,
                             blockSizeExponent,
                             threads,
+                            statusReport,
+                            id,
                         )
                     alignedSize = partitionOut.actualSize + align0x200(
                         partitionOut.actualSize

--- a/nsz/BlockCompressor.py
+++ b/nsz/BlockCompressor.py
@@ -15,8 +15,6 @@ else:
 
 
 def compressBlockTask(in_queue, out_list, readyForWork, pleaseKillYourself, blockSize):
-    if not Keys.keys_loaded:
-        Keys.load_default()
     while True:
         readyForWork.increment()
         item = in_queue.get()

--- a/nsz/Fs/Nsp.py
+++ b/nsz/Fs/Nsp.py
@@ -465,14 +465,20 @@ class Nsp(Pfs0):
             Print.info("\t\tRepack %s is already complete!" % self.path)
             return
 
-        t = enlighten.Counter(
-            total=totalSize, unit="B", desc=os.path.basename(self.path), leave=False
+        useBar = not Print.isMinimalOutput() and not Print.machineReadableOutput
+        t = (
+            enlighten.Counter(
+                total=totalSize, unit="B", desc=os.path.basename(self.path), leave=False
+            )
+            if useBar
+            else None
         )
 
         Print.info("\t\tWriting header...")
         outf = open(self.path, "wb")
         outf.write(hd)
-        t.update(len(hd))
+        if t is not None:
+            t.update(len(hd))
 
         for f_str in files:
             for filePath in expandFiles(Path(f_str)):
@@ -483,8 +489,10 @@ class Nsp(Pfs0):
                         if not buf:
                             break
                         outf.write(buf)
-                        t.update(len(buf))
-        t.close()
+                        if t is not None:
+                            t.update(len(buf))
+        if t is not None:
+            t.close()
 
         Print.info("\t\tRepacked to %s!" % outf.name)
         outf.close()


### PR DESCRIPTION
Using `nsz` as a library it is hard to control logs and terminal outputs that are forced to be printed, this PR is fully backwards-compatible and only changes the outputs when using as a library, or with `--machine-readable` or `--minimal-output` print args.

1. Add statusReport progress hook to block compression
<details>

When using `nsz` as library (not from the CLI/terminal commands), `solidCompress`, `verify`, and `decompress` all accept a `statusReport` dict that lets the application poll compression progress without going through the terminal, `blockCompress` is the only task missing it.

This extends the existing `statusReport` mechanism to the block compression, bringing it to parity with the other compressors.

The change is backwards-compatible, as the new parameters default to `None`/`0`, the CLI use is unchanged and `--machine-readable` and `--minimal-output` behaviour is untouched.

</details>

2.  Nsp repack: hide progress bar when using machine-readable/minimal-output print args

<details>

Don't show progress bars when using `--machine-readable` or `--minimal-output` print args

</details>

3. Don't load keys in block compression task

<details>

Block Compression task use multiple threads, and they all try to load Keys using nsz default loading. When used within a program where Keys are handled there, each thread will print error logs for default Keys not found.  

This Keys loading is actually dead code, as the block compression is pure zstd compression on already decrypted buffers.

</details>

I validated by running block and solid compression on nsp and xci files, using CLI and as a library, it create bit identical files in each case.