### PR TITLE
Add more tests to Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,7 +9,7 @@ pool:
 variables:
   testDir: 'C:\Users\Azure\.switch\tests'
 strategy:
-  maxParallel: 8
+  maxParallel: 4
   matrix:
     Python360:
       python.version: '3.6.0'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,8 +6,10 @@ trigger:
 pool:
   name: default
   #vmImage: 'windows-latest'
+variables:
+  testDir: 'C:\Users\Azure\.switch\tests'
 strategy:
-  maxParallel: 4
+  maxParallel: 8
   matrix:
     Python360:
       python.version: '3.6.0'
@@ -17,6 +19,14 @@ strategy:
       python.version: '3.7.6'
     Python383:
       python.version: '3.8.3'
+    #Python39:
+    #  python.version: '3.9'
+    #Python310x:
+    #  python.version: '3.10'
+    #Python311x:
+    #  python.version: '3.11'
+    #Python312x:
+    #  python.version: '3.12'
 steps:
 - task: UsePythonVersion@0
   inputs:
@@ -27,27 +37,180 @@ steps:
     python -m pip install --upgrade pip
     python -m pip install -r requirements.txt
   displayName: 'Install dependencies'
-  
+
+- script: |
+    for %%d in (out nsz_solid_out nsz_block_out nsp_from_solid_out nsp_from_block_out) do (
+      if exist "$(testDir)\%%d" rmdir /S /Q "$(testDir)\%%d"
+    )
+  displayName: 'Clean test outputs'
+
 - task: CmdLine@2
   inputs:
-    script: python nsz.py -D -V --keep -w -m 4 -t 4 -o C:\Users\Azure\.switch\tests\nsp_from_solid_out C:\Users\Azure\.switch\tests\nsz_solid
+    script: python nsz.py --info "$(testDir)\nsp"
     failOnStderr: true
-  displayName: 'Test NSZ solid decompression'
-  
+  displayName: 'Show NSP info'
+
 - task: CmdLine@2
   inputs:
-    script: python nsz.py -D -V --keep -w -m 4 -t 4 -o C:\Users\Azure\.switch\tests\nsp_from_block_out C:\Users\Azure\.switch\tests\nsz_block
+    script: python nsz.py --verify "$(testDir)\nsp"
     failOnStderr: true
-  displayName: 'Test NSZ block decompression'
-  
+  displayName: 'Verify NSP'
+
 - task: CmdLine@2
   inputs:
-    script: python nsz.py -C -V --keep -w -m 4 -t 4 -o C:\Users\Azure\.switch\tests\nsz_solid_out C:\Users\Azure\.switch\tests\nsp
+    script: python nsz.py --quick-verify "$(testDir)\nsp"
     failOnStderr: true
-  displayName: 'Test NSP solid compression'
-  
+  displayName: 'Quick-verify NSP'
+
 - task: CmdLine@2
   inputs:
-    script: python nsz.py -C -B -V --keep -w -m 4 -t 4 -o C:\Users\Azure\.switch\tests\nsz_block_out C:\Users\Azure\.switch\tests\nsp
+    script: |
+      mkdir "$(testDir)\out\nsz_solid\default"
+      python nsz.py -C -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_solid\default" "$(testDir)\nsp"
     failOnStderr: true
-  displayName: 'Test NSP block compression'
+  displayName: 'Test NSP solid compression (default level)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_solid\default"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_solid\default" "$(testDir)\nsz_solid"
+    failOnStderr: true
+  displayName: 'Test NSZ solid decompression (default level)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_block\default"
+      python nsz.py -C -B -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_block\default" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP block compression (default level)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_block\default"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_block\default" "$(testDir)\nsz_block"
+    failOnStderr: true
+  displayName: 'Test NSZ block decompression (default level)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_solid\22"
+      python nsz.py -C --level 22 -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_solid\22" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP solid compression (level 22)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_solid\22"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_solid\22" "$(testDir)\out\nsz_solid\22"
+    failOnStderr: true
+  displayName: 'Test NSZ solid decompression (level 22)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_block\22"
+      python nsz.py -C --level 22 -B -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_block\22" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP block compression (level 22)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_block\22"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_block\22" "$(testDir)\out\nsz_block\22"
+    failOnStderr: true
+  displayName: 'Test NSZ block decompression (level 22)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_solid\long"
+      python nsz.py -C --long -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_solid\long" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP solid compression (long)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_solid\long"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_solid\long" "$(testDir)\out\nsz_solid\long"
+    failOnStderr: true
+  displayName: 'Test NSZ solid decompression (long)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_block\long"
+      python nsz.py -C --long -B -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_block\long" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP block compression (long)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_block\long"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_block\long" "$(testDir)\out\nsz_block\long"
+    failOnStderr: true
+  displayName: 'Test NSZ block decompression (long)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_solid\22long"
+      python nsz.py -C --level 22 --long -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_solid\22long" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP solid compression (level 22, long)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_from_solid\22long"
+      python nsz.py -D -V --keep -w -m 4 -t 4 -o "$(testDir)\out\nsp_from_solid\22long" "$(testDir)\out\nsz_solid\22long"
+    failOnStderr: true
+  displayName: 'Test NSZ solid decompression (level 22, long)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_solid\quick"
+      python nsz.py -C --quick-verify --keep -w -m 4 -t 4 -o "$(testDir)\out\nsz_solid\quick" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP solid compression (quick-verify)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsz_solid\quickfixpadding"
+      python nsz.py -C --quick-verify --keep --fix-padding -w -m 4 -t 4 -o "$(testDir)\out\nsz_solid\quickfixpadding" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP solid compression (quick-verify, fix-padding)'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_extracted"
+      python nsz.py --extract -w -o "$(testDir)\out\nsp_extracted" "$(testDir)\nsp"
+    failOnStderr: true
+  displayName: 'Test NSP extraction'
+
+- task: CmdLine@2
+  inputs:
+    script: |
+      mkdir "$(testDir)\out\nsp_created"
+      for /d %%d in ("$(testDir)\out\nsp_extracted\*") do (
+        python nsz.py --create "$(testDir)\out\nsp_created\%%~nxd.nsp" "%%d"
+      )
+    failOnStderr: true
+  displayName: 'Test NSP creation'
+
+- script: |
+    for %%d in (out) do (
+      if exist "$(testDir)\%%d" rmdir /S /Q "$(testDir)\%%d"
+    )
+  displayName: 'Re-clean test outputs'
+  condition: always()

--- a/nsz/Fs/Nsp.py
+++ b/nsz/Fs/Nsp.py
@@ -452,8 +452,13 @@ class Nsp(Pfs0):
                 )
                 nca.header.setIsGameCard(targetValue)
 
-    def pack(self, files, fix_padding):
+    def pack(self, files, fix_padding, overwrite):
         if not self.path:
+            Print.error(601, 'Error: No output path given to Nsp.pack function!')
+            return False
+
+        if os.path.isdir(self.path):
+            Print.error(602, 'Error: Output path "{0}" is a directory!'.format(self.path))
             return False
 
         Print.info("\tRepacking to NSP...")
@@ -461,9 +466,9 @@ class Nsp(Pfs0):
         hd = self.generateHeader(files, fix_padding)
 
         totalSize = len(hd) + sum(os.path.getsize(file) for file in files)
-        if os.path.exists(self.path) and os.path.getsize(self.path) == totalSize:
+        if (not overwrite) and os.path.exists(self.path) and os.path.getsize(self.path) == totalSize:
             Print.info("\t\tRepack %s is already complete!" % self.path)
-            return
+            return True
 
         useBar = not Print.isMinimalOutput() and not Print.machineReadableOutput
         t = (
@@ -496,6 +501,8 @@ class Nsp(Pfs0):
 
         Print.info("\t\tRepacked to %s!" % outf.name)
         outf.close()
+
+        return True
 
     def generateHeader(self, files, fix_padding):
         filesNb = len(files)

--- a/nsz/__init__.py
+++ b/nsz/__init__.py
@@ -289,6 +289,7 @@ def _validate_output_mode(args):
 
     if minimalOutput:
         Print.enableInfo = False
+
     return True
 
 
@@ -351,7 +352,8 @@ def _handle_create(args):
     Print.info('Creating "{0}"'.format(args.create))
     nsp = Nsp.Nsp()
     nsp.path = args.create
-    nsp.pack(args.file, args.fix_padding)
+    if not nsp.pack(args.file, args.fix_padding, args.overwrite):
+        raise Exception
 
 
 def _adjust_compression_verify_flags(args):
@@ -362,7 +364,7 @@ def _adjust_compression_verify_flags(args):
         args.quick_verify = True
     if args.verify and not args.quick_verify and args.fix_padding:
         Print.info(
-            "Warning: --verify and --fix-padding are incompatible with each others. For compatibility reasons --quick-verify will be automatically used instead to match the command line argument behavior prior to NSZ v4.6.0."
+            "Warning: --verify and --fix-padding are incompatible with each other. For compatibility reasons --quick-verify will be automatically used instead to match the command line argument behavior prior to NSZ v4.6.0."
         )
         args.quick_verify = True
 
@@ -705,12 +707,13 @@ def main():
         args = _get_args()
         if args is None:
             return
+
         if not _validate_output_mode(args):
-            return
+            raise Exception("Invalid terminal output mode arguments.")
 
         argOutFolder, ok = _resolve_output_folder(args)
         if not ok:
-            return
+            raise Exception("Unable to open output directory.")
 
         _print_banner()
         Print.startHeartbeat()


### PR DESCRIPTION
Add more tests to Azure pipeline.


This also fixes the following issues discovered during testing:

- --create crashes when output path already exists and is a directory
- --create fails silently when no output path is given
- --create does not honor --overwrite argument
- Exit code not set when terminal output mode arguments are invalid
- Exit code not set when output folder is not resolved

---

See the following issues for tasks that need to be completed on the runners to increase test coverage:
- #241
- #242

There are also still a lot of other tests we should add, like making sure bad arguments get rejected, but this is a good start.