### PR TITLE
Fix handling of zero-size file partitions

### DIFF
--- a/nsz/Fs/File.py
+++ b/nsz/Fs/File.py
@@ -63,7 +63,7 @@ class BaseFile:
 
         n.offset = offset
 
-        if not size:
+        if size is None:
             size = self.size - n.offset - self.offset
 
         n.size = size


### PR DESCRIPTION
Fix handling of zero-size file partitions by checking explicitly for `None`.