### PR TITLE
Calculate proper nca size for nsz decompression

### DIFF
--- a/nsz/Decompressor.py
+++ b/nsz/Decompressor.py
@@ -275,8 +275,8 @@ def __getDecompressedNczSize(nspf):
         )
         sections.insert(0, fakeSection)
     nca_size = INCOMPRESSIBLE_HEADER_SIZE
-    for i in range(sectionCount):
-        nca_size += sections[i].size
+    for s in sections:
+        nca_size += s.size
     return nca_size
 
 
@@ -313,8 +313,8 @@ def __decompressNcz(
         )
         sections.insert(0, fakeSection)
     nca_size = INCOMPRESSIBLE_HEADER_SIZE
-    for i in range(sectionCount):
-        nca_size += sections[i].size
+    for s in sections:
+        nca_size += s.size
     pos = nspf.tell()
     blockMagic = nspf.read(8)
     nspf.seek(pos)


### PR DESCRIPTION
Fix for #247

This size will be used to create section offsets/sizes in header.

Error happens if original nsp file has nca file with larger than 0x4000 bytes for offset in first section. Then it ignored last section size, so header contained incorrect sizes/offsets and sha256 verify on nsp would fail.

Now code correctly uses FakeHeader to properly calculate original values to fix everything back. Output NSP file should match byte-by-byte.

I've tested this is two nsp files - one with 0x4200 section offset, other with 0x120 offset. For both the NSP->NSZ->NSP trip works fine.